### PR TITLE
Add types for `testing` property on default aws-lite export.

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -53,7 +53,33 @@ export interface AwsLiteClient {
   (payload: AwsLiteRequest): Promise<AwsLiteResponse>;
 }
 
+interface AwsLiteBaseMock {
+  method: string;
+  time: string;
+}
+interface AwsLiteMockRequest extends AwsLiteBaseMock {
+  request: any;
+}
+interface AwsLiteMockResponse extends AwsLiteBaseMock {
+  response: any;
+}
+
+interface AwsLiteTesting {
+  debug: (args?: { print?: boolean }) => any;
+  disable: () => void;
+  enable: (args?: { usePluginResponseMethod?: boolean }) => void;
+  getAllRequests: (target?: string) => AwsLiteMockRequest[];
+  getAllResponses: (target?: string) => AwsLiteMockRequest[];
+  getLastRequest: (target?: string) => AwsLiteMockRequest;
+  getLastResponse: (target?: string) => AwsLiteMockResponse;
+  mock: (target: string, mock: any) => void;
+  reset: () => void;
+}
+
 declare module "@aws-lite/client" {
-  const CreateAwsLite: (config?: AwsLiteConfig) => Promise<AwsLiteClient>;
+  const CreateAwsLite: {
+    (config?: AwsLiteConfig): Promise<AwsLiteClient>;
+    testing: AwsLiteTesting;
+  }
   export = CreateAwsLite;
 }


### PR DESCRIPTION
So my IDE will stop complaining about me using `awsLite.testing` in my tests 😄 

The mock request/response shapes are based on the logic in [the `getMock` function of client-factory](https://github.com/aws-lite/aws-lite/blob/main/src/client-factory.js#L227-L272) - possibly could augment these types a bit more. Let me know if you think that's worth it. One potential augmentation would be to add `statusCode`, `headers` and `payload` properties to the `AwsLiteMockResponse` interface (based on [this code in `getMock`](https://github.com/aws-lite/aws-lite/blob/main/src/client-factory.js#L254-L261)) - but because these are only properties tacked on if you set `usePluginResponseMethod` when calling `enable()`, they are not guaranteed to be present. Not sure if it's worth it / how to model that? Optional properties? A separate interface altogether?

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
