### PR TITLE
Tests to demonstrate that taken cant be found if profile uses an sso_session_name

### DIFF
--- a/test/mock/.aws/config
+++ b/test/mock/.aws/config
@@ -9,6 +9,11 @@ endpoint_url=https://lolidk.net
 [profile profile_2]
 region = us-east-1
 
+[profile profile_with_session_name]
+sso_session = sso-config
+sso_account_id = 123456789
+sso_role_name = MySSORoleName
+
 [sso-session sso-config]
 sso_region = us-east-2
 sso_start_url = https://sso-domain.awsapps.com/start

--- a/test/unit/src/config/get-creds-test.mjs
+++ b/test/unit/src/config/get-creds-test.mjs
@@ -81,10 +81,10 @@ test('Get credentials from env vars', async t => {
 })
 
 test('Get credentials from SSO', async t => {
-  t.plan(18)
+  t.plan(19)
   let homedir, result, request
   let ssoPath = '.aws/sso/cache/1d4488e85b2549abce77758ec396e9e37332312b.json'
-
+  let ssoSessionPath = '.aws/sso/cache/03f7c6869a0b1544548ead77b47666a8bd130c99.json'
   let started = await server.start()
   t.ok(started, 'Started server')
 
@@ -108,6 +108,7 @@ test('Get credentials from SSO', async t => {
   homedir = mockTmp({
     '.aws': mockTmp.copy(awsIniMock),
     [ssoPath]: mockTmp.copy(join(awsSSOMock, 'valid.json')),
+    [ssoSessionPath]: mockTmp.copy(join(awsSSOMock, 'valid.json')),
   })
   overrideHomedir(homedir)
 
@@ -135,6 +136,23 @@ test('Get credentials from SSO', async t => {
   t.equal(request.url, '/federation/credentials?account_id=123456789012&role_name=eh', 'Fetched correct URL')
   t.equal(request.headers['x-amz-sso_bearer_token'], 'an-access-token', 'Used correct authorization header')
   t.deepEqual(result, roleCredentials, 'Fetched creds from SSO portal')
+
+  mockTmp.reset()
+  // SSO profile with session name
+  try {
+    let result = await getCreds({
+      config: {
+        sso: { endpoint: `http://${host}:${port}` },
+        profile: 'profile_with_session_name',
+        awsConfigFile: true,
+      },
+    })
+    t.deepEqual(result, roleCredentials, 'Creds obtained using session name hash')
+  }
+  catch (err) {
+    console.log(err)
+    t.fail("Can't find cache token using session name hash")
+  }
 
   mockTmp.reset()
 


### PR DESCRIPTION
Test to demonstrate SSO cache filename issue #166 

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [x] Expanded test coverage related to your changes:
  - [x] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
